### PR TITLE
client: return existing members list on add_member

### DIFF
--- a/aetcd3/client.py
+++ b/aetcd3/client.py
@@ -1,3 +1,4 @@
+from typing import List, Tuple
 import asyncio
 import functools
 import inspect
@@ -731,7 +732,10 @@ class Etcd3Client:
 
     @_handle_errors
     @_ensure_channel
-    async def add_member(self, urls):
+    async def add_member(
+        self,
+        urls: List[str]
+    ) -> Tuple[members.Member, List[members.Member]]:
         """
         Add a member into the cluster.
 
@@ -746,14 +750,25 @@ class Etcd3Client:
             metadata=self.metadata,
         )
 
-        member = member_add_response.member
-        return members.Member(
-            member.ID,
-            member.name,
-            member.peerURLs,
-            member.clientURLs,
+        member_res: members.Member = member_add_response.member
+        nodes_lst: List[members.Member] = []
+        for node in member_add_response.members:
+            nodes_lst.append(
+                members.Member(
+                    node.ID,
+                    node.name,
+                    node.peerURLs,
+                    node.clientURLs
+                )
+            )
+        member = members.Member(
+            member_res.ID,
+            member_res.name,
+            member_res.peerURLs,
+            member_res.clientURLs,
             etcd_client=self,
         )
+        return member, nodes_lst
 
     @_handle_errors
     @_ensure_channel


### PR DESCRIPTION
Returning just the newly added member provides no additional benefit to
the caller: the caller already knows which member it is adding, and is
left without any clue as to the remaining cluster.

In contrast, when the same command is run through 'etcdctl', one ends up
with a neat list of existing members that can then be provided to the
newly added member.

This patch aims at providing this additional context that is so much
needed in some situations.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>